### PR TITLE
Remove 'datetime' dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(name='bsm_model',
       author='Leopold W.',
       author_email='lsw@lwco.com',
       packages=find_packages(exclude=("tests", "tests_dev")),
-      install_requires=['pandas', 'numpy', 'scipy', 'datetime'],
+      install_requires=['pandas', 'numpy', 'scipy'],
       )


### PR DESCRIPTION
The datetime module is a Python builtin. Requiring 'datetime' means that an unneeded 'DateTime' package is installed: https://pypi.org/project/DateTime/